### PR TITLE
fix: add jsconfig.json to resolve module import errors

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
Added jsconfig.json configuration to enable absolute imports starting with "src/".
This fixes the "Module not found: Can't resolve 'src/components/Layout'" error.

Fixes #5

Generated with [Claude Code](https://claude.ai/code)