### PR TITLE
fix: prop-typesパッケージを依存関係に追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eslint": "8.29.0",
     "eslint-config-next": "13.0.6",
     "next": "^13.0.6",
+    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }


### PR DESCRIPTION
## 概要

Vercelデプロイエラーを解決するため、package.jsonにprop-typesパッケージを追加しました。

## 変更内容
- package.jsonの依存関係に`"prop-types": "^15.8.1"`を追加

Fixes #14

Generated with [Claude Code](https://claude.ai/code)