### PR TITLE
Add default export for LazyFeature component

### DIFF
--- a/src/components/LazyFeature/index.jsx
+++ b/src/components/LazyFeature/index.jsx
@@ -22,3 +22,4 @@ export const LazyFeature = () => {
     </div>
   );
 };
+export default LazyFeature;


### PR DESCRIPTION
## Summary
- export LazyFeature component by default for React.lazy usage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848e76c37408333a0540cec6cce97b5