### PR TITLE
Fix README reference to index page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ yarn dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `src/pages/index.jsx`. The page auto-updates as you edit the file.
 
 [API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
 


### PR DESCRIPTION
## Summary
- update README reference to `src/pages/index.jsx`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848e76d20f8833399146ff74b3da244