### PR TITLE
日本語デザイン改善: フォント・コントラスト・アクセシビリティ向全

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -33,7 +33,8 @@
 
 .userEmail {
   font-size: 0.9rem;
-  color: #666;
+  color: #4a5568;
+  font-weight: 500;
 }
 
 .loginButton {
@@ -56,7 +57,7 @@
   background: none;
   border: 1px solid #e0e0e0;
   border-radius: 20px;
-  color: #666;
+  color: #4a5568;
   cursor: pointer;
   font-weight: 500;
   transition: all 0.3s ease;

--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -15,8 +15,10 @@ export const Layout = ({ children, title = "Study React App" }) => {
         <meta property="og:title" content={title} />
         <meta property="og:description" content="Reactの学習用アプリケーション" />
         <meta property="og:type" content="website" />
+        <meta property="og:locale" content="ja_JP" />
         <link rel="icon" href="/favicon.ico" />
         <link rel="canonical" href={typeof window !== 'undefined' ? window.location.href : ''} />
+        <html lang="ja" />
       </Head>
       <Header />
       <main role="main" className={classes.main}>

--- a/src/styles/Login.module.css
+++ b/src/styles/Login.module.css
@@ -39,8 +39,9 @@
 
 .subtitle {
   text-align: center;
-  color: #666;
+  color: #4a5568;
   margin-bottom: 2rem;
+  font-weight: 500;
 }
 
 .form {
@@ -160,7 +161,7 @@
   position: relative;
   padding: 0 1rem;
   background: white;
-  color: #666;
+  color: #4a5568;
   font-size: 0.9rem;
 }
 
@@ -195,7 +196,7 @@
 .footer {
   text-align: center;
   margin-top: 2rem;
-  color: #666;
+  color: #4a5568;
   font-size: 0.9rem;
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,9 +1,15 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap');
+
 html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+  font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic Medium", "Meiryo", "MS PGothic", -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  line-height: 1.7;
+  font-feature-settings: "palt" 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 


### PR DESCRIPTION
## 概要
日本語テキストの見やすさを改善し、アクセシビリティを向上させました。

## 主な改善点
- 日本語フォント追加: Noto Sans JP、Hiragino Sans優先設定
- コントラスト改善: #6666 → #4a5568 (WCAG準拠)
- アクセシビリティ向上: lang=ja属性、日本語ロケール追加

Closes #46

Generated with [Claude Code](https://claude.ai/code)