### PR TITLE
Relocate html lang attribute

### DIFF
--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -18,7 +18,6 @@ export const Layout = ({ children, title = "Study React App" }) => {
         <meta property="og:locale" content="ja_JP" />
         <link rel="icon" href="/favicon.ico" />
         <link rel="canonical" href={typeof window !== 'undefined' ? window.location.href : ''} />
-        <html lang="ja" />
       </Head>
       <Header />
       <main role="main" className={classes.main}>

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="ja">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}


### PR DESCRIPTION
Move `lang="ja"` attribute from `Head` component to `_document.js` to fix invalid HTML structure.

The `<html lang="ja" />` element was incorrectly placed inside the Next.js `<Head>` component, leading to invalid HTML and potential React hydration errors. This PR correctly sets the `lang` attribute on the `<html>` element by creating a custom `_document.js` file, which is the recommended Next.js approach for global document customization.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-9a1e8330-39eb-4cee-9a26-6a73aabd9824) · [Cursor](https://cursor.com/background-agent?bcId=bc-9a1e8330-39eb-4cee-9a26-6a73aabd9824)