### PR TITLE
Fix header layout by removing inappropriate flexbox centering

### DIFF
--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -1,10 +1,8 @@
 .container {
-  padding: 0 2rem;
+  padding: 0;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
 }
 
 .main {
@@ -12,10 +10,11 @@
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
+  padding: 2rem;
 }
 
 @media (max-width: 768px) {
-  .container {
-    padding: 0 1rem;
+  .main {
+    padding: 1rem;
   }
 }


### PR DESCRIPTION
## Summary
- Remove justify-content: center and align-items: center from Layout container
- Move padding from container to main content area
- Update responsive design to target main content
- Header now displays at top of page instead of center

## Test plan
- [ ] Verify header appears at top of page
- [ ] Check layout on different screen sizes
- [ ] Confirm main content has proper spacing

Generated with [Claude Code](https://claude.ai/code)