### PR TITLE
refactor: extract keydown handler utility

### DIFF
--- a/__tests__/keyboard.test.js
+++ b/__tests__/keyboard.test.js
@@ -1,0 +1,77 @@
+import { createKeyDownHandler } from '../src/utils/keyboard'
+
+describe('createKeyDownHandler', () => {
+  let mockHandler;
+  let mockEvent;
+
+  beforeEach(() => {
+    mockHandler = jest.fn();
+    mockEvent = {
+      key: '',
+      preventDefault: jest.fn(),
+    };
+  });
+
+  test('calls handler when Enter key is pressed', () => {
+    const keyDownHandler = createKeyDownHandler(mockHandler);
+    mockEvent.key = 'Enter';
+
+    keyDownHandler(mockEvent);
+
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(mockHandler).toHaveBeenCalledWith(mockEvent);
+  });
+
+  test('calls handler when Space key is pressed', () => {
+    const keyDownHandler = createKeyDownHandler(mockHandler);
+    mockEvent.key = ' ';
+
+    keyDownHandler(mockEvent);
+
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(mockHandler).toHaveBeenCalledWith(mockEvent);
+  });
+
+  test('does not call handler for other keys', () => {
+    const keyDownHandler = createKeyDownHandler(mockHandler);
+    mockEvent.key = 'Tab';
+
+    keyDownHandler(mockEvent);
+
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+    expect(mockHandler).not.toHaveBeenCalled();
+  });
+
+  test('returns empty function when handler is not a function', () => {
+    console.warn = jest.fn();
+    const keyDownHandler = createKeyDownHandler('not a function');
+    mockEvent.key = 'Enter';
+
+    keyDownHandler(mockEvent);
+
+    expect(console.warn).toHaveBeenCalledWith('createKeyDownHandler: handler must be a function');
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+  });
+
+  test('handles null handler gracefully', () => {
+    console.warn = jest.fn();
+    const keyDownHandler = createKeyDownHandler(null);
+    mockEvent.key = 'Enter';
+
+    keyDownHandler(mockEvent);
+
+    expect(console.warn).toHaveBeenCalledWith('createKeyDownHandler: handler must be a function');
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+  });
+
+  test('handles undefined handler gracefully', () => {
+    console.warn = jest.fn();
+    const keyDownHandler = createKeyDownHandler(undefined);
+    mockEvent.key = 'Enter';
+
+    keyDownHandler(mockEvent);
+
+    expect(console.warn).toHaveBeenCalledWith('createKeyDownHandler: handler must be a function');
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Counter/index.jsx
+++ b/src/components/Counter/index.jsx
@@ -1,28 +1,22 @@
 import { memo } from "react";
 import PropTypes from "prop-types";
+import { createKeyDownHandler } from "src/utils/keyboard";
 import classes from "./Counter.module.css";
 
 const CounterComponent = ({ count, isShow, handleClick, handleDisplay }) => {
-  const handleKeyDown = (handler) => (e) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handler();
-    }
-  };
-
   return (
     <div className={classes.counter}>
       {isShow ? <h2 tabIndex="0" aria-live="polite">{count}</h2> : null}
-      <button 
-        onClick={handleClick} 
-        onKeyDown={handleKeyDown(handleClick)}
+      <button
+        onClick={handleClick}
+        onKeyDown={createKeyDownHandler(handleClick)}
         aria-label="カウントを増やす"
       >
         ボタン
       </button>
-      <button 
-        onClick={handleDisplay} 
-        onKeyDown={handleKeyDown(handleDisplay)}
+      <button
+        onClick={handleDisplay}
+        onKeyDown={createKeyDownHandler(handleDisplay)}
         aria-label={isShow ? "カウントを非表示にする" : "カウントを表示する"}
       >
         {isShow ? "非表示" : "表示"}

--- a/src/components/Counter/index.jsx
+++ b/src/components/Counter/index.jsx
@@ -1,22 +1,32 @@
-import { memo } from "react";
+import { memo, useCallback } from "react";
 import PropTypes from "prop-types";
 import { createKeyDownHandler } from "src/utils/keyboard";
 import classes from "./Counter.module.css";
 
 const CounterComponent = ({ count, isShow, handleClick, handleDisplay }) => {
+  const handleClickKeyDown = useCallback(
+    createKeyDownHandler(handleClick),
+    [handleClick]
+  );
+  
+  const handleDisplayKeyDown = useCallback(
+    createKeyDownHandler(handleDisplay),
+    [handleDisplay]
+  );
+
   return (
     <div className={classes.counter}>
       {isShow ? <h2 tabIndex="0" aria-live="polite">{count}</h2> : null}
       <button
         onClick={handleClick}
-        onKeyDown={createKeyDownHandler(handleClick)}
+        onKeyDown={handleClickKeyDown}
         aria-label="カウントを増やす"
       >
         ボタン
       </button>
       <button
         onClick={handleDisplay}
-        onKeyDown={createKeyDownHandler(handleDisplay)}
+        onKeyDown={handleDisplayKeyDown}
         aria-label={isShow ? "カウントを非表示にする" : "カウントを表示する"}
       >
         {isShow ? "非表示" : "表示"}

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -2,6 +2,7 @@ import { memo, useState, useMemo, useEffect, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useApp } from "src/contexts/AppContext";
+import { createKeyDownHandler } from "src/utils/keyboard";
 import classes from "./Header.module.css";
 
 const NAV_ITEMS = [
@@ -33,12 +34,7 @@ export const Header = memo(() => {
     setMobileMenuOpen(!mobileMenuOpen);
   };
 
-  const handleKeyDown = (event) => {
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      handleMobileMenuToggle();
-    }
-  };
+  const handleKeyDown = createKeyDownHandler(handleMobileMenuToggle);
 
   const handleEscapeKey = (event) => {
     if (event.key === 'Escape' && mobileMenuOpen) {

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo, useEffect, useRef } from "react";
+import { memo, useState, useMemo, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useApp } from "src/contexts/AppContext";
@@ -34,7 +34,10 @@ export const Header = memo(() => {
     setMobileMenuOpen(!mobileMenuOpen);
   };
 
-  const handleKeyDown = createKeyDownHandler(handleMobileMenuToggle);
+  const handleKeyDown = useCallback(
+    createKeyDownHandler(handleMobileMenuToggle),
+    [handleMobileMenuToggle]
+  );
 
   const handleEscapeKey = (event) => {
     if (event.key === 'Escape' && mobileMenuOpen) {

--- a/src/utils/keyboard.js
+++ b/src/utils/keyboard.js
@@ -1,6 +1,21 @@
-export const createKeyDownHandler = (handler) => (event) => {
-  if (event.key === 'Enter' || event.key === ' ') {
-    event.preventDefault();
-    handler(event);
+/**
+ * Creates a keydown event handler that triggers on Enter and Space keys
+ * @param {Function} handler - The callback function to execute when Enter or Space is pressed
+ * @returns {Function} Event handler function for keydown events
+ * @example
+ * const handleKeyDown = createKeyDownHandler(() => console.log('activated'));
+ * <button onKeyDown={handleKeyDown}>Click me</button>
+ */
+export const createKeyDownHandler = (handler) => {
+  if (typeof handler !== 'function') {
+    console.warn('createKeyDownHandler: handler must be a function');
+    return () => {};
   }
+
+  return (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handler(event);
+    }
+  };
 };

--- a/src/utils/keyboard.js
+++ b/src/utils/keyboard.js
@@ -1,0 +1,6 @@
+export const createKeyDownHandler = (handler) => (event) => {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault();
+    handler(event);
+  }
+};


### PR DESCRIPTION
## Summary
- extract reusable `createKeyDownHandler` utility for keyboard accessibility
- simplify Counter and Header components by using the new utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68976c586a5c83338751051bbca52946