### PR TITLE
Add Grok-style AI companion with moods, memory, UI and tests

### DIFF
--- a/__tests__/GrokCompanion.test.jsx
+++ b/__tests__/GrokCompanion.test.jsx
@@ -190,4 +190,41 @@ describe("GrokCompanion", () => {
     // Verify crypto.getRandomValues was called for ID generation
     expect(mockCrypto.getRandomValues).toHaveBeenCalled();
   });
+
+  test("handles error cases in memory extraction gracefully", () => {
+    render(<GrokCompanion />);
+
+    const textarea = screen.getByLabelText("メッセージを入力");
+    
+    // 異常な入力ケースをテスト
+    const maliciousInputs = [
+      "覚えて: <script>alert('xss')</script>",
+      "覚えて: " + "a".repeat(300), // 異常に長い入力
+    ];
+
+    maliciousInputs.forEach((input) => {
+      fireEvent.change(textarea, { target: { value: input } });
+      fireEvent.keyDown(textarea, { key: "Enter" });
+      // エラーが発生してもクラッシュしないことを確認
+      expect(screen.getByRole("log")).toBeInTheDocument();
+    });
+  });
+
+  test("properly cleans up timeouts on component unmount", () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+    
+    const { unmount } = render(<GrokCompanion />);
+    
+    const textarea = screen.getByLabelText("メッセージを入力");
+    fireEvent.change(textarea, { target: { value: "テスト" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    // コンポーネントをアンマウント
+    unmount();
+
+    // clearTimeoutが呼ばれることを確認
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    
+    clearTimeoutSpy.mockRestore();
+  });
 });

--- a/__tests__/GrokCompanion.test.jsx
+++ b/__tests__/GrokCompanion.test.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { GrokCompanion } from 'src/components/GrokCompanion';
+import React from "react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
+import { GrokCompanion } from "src/components/GrokCompanion";
 
 // Mock crypto for Node.js environment
 const mockCrypto = {
@@ -9,156 +9,184 @@ const mockCrypto = {
       arr[i] = Math.floor(Math.random() * 256);
     }
     return arr;
-  })
+  }),
 };
 
-// Setup global crypto mock
+// Setup crypto mock for Node.js and jsdom environments
 global.crypto = mockCrypto;
 
-describe('GrokCompanion', () => {
+describe("GrokCompanion", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     mockCrypto.getRandomValues.mockClear();
+    Object.defineProperty(window, "crypto", {
+      configurable: true,
+      value: mockCrypto,
+    });
   });
 
   afterEach(() => {
-    jest.runOnlyPendingTimers();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
     jest.useRealTimers();
   });
 
-  test('renders the component correctly', () => {
+  test("renders the component correctly", () => {
     render(<GrokCompanion />);
-    
-    expect(screen.getByText('Grok Companion')).toBeInTheDocument();
-    expect(screen.getByLabelText('メッセージを入力')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /送信/ })).toBeInTheDocument();
+
+    expect(screen.getByText(/Grok Companion/)).not.toBeNull();
+    expect(screen.getByLabelText("メッセージを入力")).not.toBeNull();
+    expect(screen.getByRole("button", { name: /送信/ })).not.toBeNull();
   });
 
-  test('displays initial intro message', () => {
+  test("displays initial intro message", () => {
     render(<GrokCompanion />);
-    
-    expect(screen.getByText(/GROK COMPANION オンライン/)).toBeInTheDocument();
+
+    expect(screen.getByText(/GROK COMPANION オンライン/)).not.toBeNull();
   });
 
-  test('can send a message', async () => {
+  test("can send a message", () => {
     render(<GrokCompanion />);
-    
-    const textarea = screen.getByLabelText('メッセージを入力');
-    const sendButton = screen.getByRole('button', { name: /送信/ });
-    
-    fireEvent.change(textarea, { target: { value: 'テストメッセージ' } });
+
+    const textarea = screen.getByLabelText("メッセージを入力");
+    const sendButton = screen.getByRole("button", { name: /送信/ });
+
+    fireEvent.change(textarea, { target: { value: "テストメッセージ" } });
     fireEvent.click(sendButton);
-    
-    expect(screen.getByText('テストメッセージ')).toBeInTheDocument();
-    expect(textarea.value).toBe('');
+
+    expect(screen.getByText("テストメッセージ")).not.toBeNull();
+    expect(textarea.value).toBe("");
   });
 
-  test('shows typing indicator when processing response', () => {
+  test("shows typing indicator when processing response", () => {
     render(<GrokCompanion />);
-    
-    const textarea = screen.getByLabelText('メッセージを入力');
-    fireEvent.change(textarea, { target: { value: 'テスト' } });
-    fireEvent.keyDown(textarea, { key: 'Enter' });
-    
-    expect(screen.getByText('応答を生成中…')).toBeInTheDocument();
+
+    const textarea = screen.getByLabelText("メッセージを入力");
+    fireEvent.change(textarea, { target: { value: "テスト" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByText("応答を生成中…")).not.toBeNull();
   });
 
-  test('can change snark level', () => {
+  test("can switch companion mood modes", () => {
     render(<GrokCompanion />);
-    
-    const slider = screen.getByRole('slider');
-    fireEvent.change(slider, { target: { value: '2' } });
-    
-    expect(screen.getByText('FULL GROK')).toBeInTheDocument();
+
+    const deepDiveButton = screen.getByRole("button", { name: /Deep Dive/ });
+    fireEvent.click(deepDiveButton);
+
+    expect(deepDiveButton.getAttribute("aria-pressed")).toBe("true");
   });
 
-  test('can select topic buttons', () => {
+  test("stores memory notes from conversation", () => {
     render(<GrokCompanion />);
-    
-    const topicButton = screen.getByRole('button', { name: /量子コーヒーメーカー問題/ });
+
+    const textarea = screen.getByLabelText("メッセージを入力");
+    fireEvent.change(textarea, { target: { value: "覚えて: コーヒー派" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByText(/1\. コーヒー派/)).not.toBeNull();
+    expect(screen.getByText("1")).not.toBeNull();
+  });
+
+  test("can change snark level", () => {
+    render(<GrokCompanion />);
+
+    const slider = screen.getByRole("slider");
+    fireEvent.change(slider, { target: { value: "2" } });
+
+    expect(screen.getAllByText("FULL GROK").length).toBeGreaterThan(0);
+  });
+
+  test("can select topic buttons", () => {
+    render(<GrokCompanion />);
+
+    const topicButton = screen.getByRole("button", {
+      name: /量子コーヒーメーカー問題/,
+    });
     fireEvent.click(topicButton);
-    
-    expect(topicButton).toHaveAttribute('aria-pressed', 'true');
+
+    expect(topicButton.getAttribute("aria-pressed")).toBe("true");
   });
 
-  test('can clear conversation', () => {
+  test("can clear conversation", () => {
     render(<GrokCompanion />);
-    
+
     // Send a message first
-    const textarea = screen.getByLabelText('メッセージを入力');
-    fireEvent.change(textarea, { target: { value: 'テスト' } });
-    fireEvent.keyDown(textarea, { key: 'Enter' });
-    
+    const textarea = screen.getByLabelText("メッセージを入力");
+    fireEvent.change(textarea, { target: { value: "テスト" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
     // Clear conversation
-    const clearButton = screen.getByRole('button', { name: /ログをクリア/ });
+    const clearButton = screen.getByRole("button", { name: /ログをクリア/ });
     fireEvent.click(clearButton);
-    
+
     // Should only show intro message
     const messages = screen.getAllByText(/GROK COMPANION オンライン/);
     expect(messages).toHaveLength(1);
   });
 
-  test('handles keyboard shortcuts', () => {
+  test("handles keyboard shortcuts", () => {
     render(<GrokCompanion />);
-    
-    const textarea = screen.getByLabelText('メッセージを入力');
-    
+
+    const textarea = screen.getByLabelText("メッセージを入力");
+
     // Test Ctrl+K shortcut
-    fireEvent.keyDown(textarea, { key: 'k', ctrlKey: true });
-    
+    fireEvent.keyDown(textarea, { key: "k", ctrlKey: true });
+
     // Should clear and show only intro message
-    expect(screen.getByText(/GROK COMPANION オンライン/)).toBeInTheDocument();
+    expect(screen.getByText(/GROK COMPANION オンライン/)).not.toBeNull();
   });
 
-  test('sends message on Enter keypress', () => {
+  test("sends message on Enter keypress", () => {
     render(<GrokCompanion />);
-    
-    const textarea = screen.getByLabelText('メッセージを入力');
-    fireEvent.change(textarea, { target: { value: 'Enterテスト' } });
-    fireEvent.keyDown(textarea, { key: 'Enter' });
-    
-    expect(screen.getByText('Enterテスト')).toBeInTheDocument();
+
+    const textarea = screen.getByLabelText("メッセージを入力");
+    fireEvent.change(textarea, { target: { value: "Enterテスト" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByText("Enterテスト")).not.toBeNull();
   });
 
-  test('adds new line on Shift+Enter', () => {
+  test("adds new line on Shift+Enter", () => {
     render(<GrokCompanion />);
-    
-    const textarea = screen.getByLabelText('メッセージを入力');
-    fireEvent.change(textarea, { target: { value: 'Line 1' } });
-    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
-    
+
+    const textarea = screen.getByLabelText("メッセージを入力");
+    fireEvent.change(textarea, { target: { value: "Line 1" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
     // Should not send message, textarea should still have value
-    expect(textarea.value).toBe('Line 1');
-    expect(screen.queryByText('Line 1')).not.toBeInTheDocument();
+    expect(textarea.value).toBe("Line 1");
+    expect(screen.getByRole("log").textContent).not.toContain("Line 1");
   });
 
-  test('displays session statistics correctly', () => {
+  test("displays session statistics correctly", () => {
     render(<GrokCompanion />);
-    
-    expect(screen.getByText(/CHAOS INDEX/)).toBeInTheDocument();
-    expect(screen.getByText(/SESSION EXCHANGES/)).toBeInTheDocument();
-    expect(screen.getByText(/EMPATHY BUFFER/)).toBeInTheDocument();
+
+    expect(screen.getByText(/CHAOS INDEX/)).not.toBeNull();
+    expect(screen.getByText(/SESSION EXCHANGES/)).not.toBeNull();
+    expect(screen.getByText(/EMPATHY BUFFER/)).not.toBeNull();
   });
 
-  test('disables send button when input is empty', () => {
+  test("disables send button when input is empty", () => {
     render(<GrokCompanion />);
-    
-    const sendButton = screen.getByRole('button', { name: /送信/ });
-    expect(sendButton).toBeDisabled();
-    
-    const textarea = screen.getByLabelText('メッセージを入力');
-    fireEvent.change(textarea, { target: { value: 'テスト' } });
-    
-    expect(sendButton).not.toBeDisabled();
+
+    const sendButton = screen.getByRole("button", { name: /送信/ });
+    expect(sendButton.disabled).toBe(true);
+
+    const textarea = screen.getByLabelText("メッセージを入力");
+    fireEvent.change(textarea, { target: { value: "テスト" } });
+
+    expect(sendButton.disabled).toBe(false);
   });
 
-  test('uses secure random values when crypto is available', () => {
+  test("uses secure random values when crypto is available", () => {
     render(<GrokCompanion />);
-    
-    const textarea = screen.getByLabelText('メッセージを入力');
-    fireEvent.change(textarea, { target: { value: 'テスト' } });
-    fireEvent.keyDown(textarea, { key: 'Enter' });
-    
+
+    const textarea = screen.getByLabelText("メッセージを入力");
+    fireEvent.change(textarea, { target: { value: "テスト" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
     // Verify crypto.getRandomValues was called for ID generation
     expect(mockCrypto.getRandomValues).toHaveBeenCalled();
   });

--- a/src/components/GrokCompanion/GrokCompanion.module.css
+++ b/src/components/GrokCompanion/GrokCompanion.module.css
@@ -20,12 +20,23 @@
   --user: #20c997;
   --text-primary: #f2f4ff;
   --text-secondary: rgba(255, 255, 255, 0.72);
-  background: radial-gradient(circle at 20% 20%, rgba(125, 107, 255, 0.25), transparent 60%),
-    radial-gradient(circle at 80% 10%, rgba(0, 199, 255, 0.15), transparent 55%),
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(125, 107, 255, 0.25),
+      transparent 60%
+    ),
+    radial-gradient(
+      circle at 80% 10%,
+      rgba(0, 199, 255, 0.15),
+      transparent 55%
+    ),
     #05060e;
   border-radius: 32px;
   border: 1px solid rgba(255, 255, 255, 0.06);
-  box-shadow: 0 28px 60px rgba(5, 6, 14, 0.65), inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  box-shadow:
+    0 28px 60px rgba(5, 6, 14, 0.65),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.02);
   color: var(--text-primary);
   display: grid;
   gap: 24px;
@@ -40,7 +51,11 @@
   position: absolute;
   inset: 12px;
   border-radius: 24px;
-  background: linear-gradient(135deg, rgba(125, 107, 255, 0.15), transparent 45%);
+  background: linear-gradient(
+    135deg,
+    rgba(125, 107, 255, 0.15),
+    transparent 45%
+  );
   pointer-events: none;
   z-index: 0;
 }
@@ -138,6 +153,101 @@
   color: var(--text-secondary);
 }
 
+.personaPanel {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(260px, 1.5fr);
+  gap: 18px;
+  padding: 20px;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(135deg, rgba(32, 201, 151, 0.14), transparent 44%),
+    rgba(7, 9, 17, 0.78);
+}
+
+.personaCopy {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+}
+
+.kicker {
+  color: var(--user);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.personaCopy h2 {
+  margin: 0;
+  font-size: clamp(1.2rem, 2.4vw, 1.7rem);
+}
+
+.personaCopy p,
+.memoryPanel p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.moodGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.moodButton {
+  min-height: 118px;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 10px;
+  text-align: left;
+}
+
+.moodButton span {
+  font-weight: 700;
+}
+
+.moodButton small {
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.moodButton[aria-pressed="true"] {
+  background: linear-gradient(
+    135deg,
+    rgba(125, 107, 255, 0.34),
+    rgba(32, 201, 151, 0.16)
+  );
+  border-color: rgba(125, 107, 255, 0.7);
+  box-shadow: 0 0 18px rgba(125, 107, 255, 0.32);
+}
+
+.memoryPanel {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.systemList {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-secondary);
+  display: grid;
+  gap: 4px;
+}
+
 .snarkControl {
   position: relative;
   z-index: 1;
@@ -146,7 +256,11 @@
   padding: 18px;
   border-radius: 20px;
   border: 1px solid rgba(255, 255, 255, 0.07);
-  background: linear-gradient(135deg, rgba(125, 107, 255, 0.18), rgba(255, 255, 255, 0.05));
+  background: linear-gradient(
+    135deg,
+    rgba(125, 107, 255, 0.18),
+    rgba(255, 255, 255, 0.05)
+  );
 }
 
 .snarkHeader {
@@ -204,7 +318,9 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  transition: transform 0.2s ease, background 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    background 0.2s ease;
   cursor: pointer;
 }
 
@@ -335,7 +451,9 @@
   padding: 10px 14px;
   border-radius: 999px;
   font-size: 0.85rem;
-  transition: background 0.2s ease, transform 0.2s ease;
+  transition:
+    background 0.2s ease,
+    transform 0.2s ease;
   cursor: pointer;
 }
 
@@ -400,7 +518,9 @@
   font-size: 0.92rem;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .sendButton {
@@ -441,6 +561,14 @@
     min-height: 320px;
   }
 
+  .personaPanel {
+    grid-template-columns: 1fr;
+  }
+
+  .moodGrid {
+    grid-template-columns: 1fr;
+  }
+
   .inputFooter {
     flex-direction: column;
     align-items: stretch;
@@ -459,6 +587,7 @@
 @media (prefers-reduced-motion: reduce) {
   .topicButton,
   .quickButton,
+  .moodButton,
   .sendButton,
   .clearButton {
     transition: none;
@@ -467,7 +596,7 @@
   .dot {
     animation: none;
   }
-  
+
   /* Disable will-change for users with reduced motion preference */
   .chatWindow {
     will-change: auto;

--- a/src/components/GrokCompanion/GrokCompanion.module.css
+++ b/src/components/GrokCompanion/GrokCompanion.module.css
@@ -333,7 +333,11 @@
 .topicButton:hover,
 .topicButton:focus-visible {
   background: rgba(255, 255, 255, 0.12);
-  outline: none;
+}
+
+.topicButton:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .chatWindow {
@@ -457,11 +461,16 @@
   cursor: pointer;
 }
 
-.quickButton:hover,
+.quickButton:hover {
+  transform: translateY(-1px);
+  background: rgba(255, 255, 255, 0.12);
+}
+
 .quickButton:focus-visible {
   transform: translateY(-1px);
   background: rgba(255, 255, 255, 0.12);
-  outline: none;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .inputArea {
@@ -542,12 +551,17 @@
 }
 
 .sendButton:not(:disabled):hover,
+.clearButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(125, 107, 255, 0.4);
+}
+
 .sendButton:not(:disabled):focus-visible,
-.clearButton:hover,
 .clearButton:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 10px 24px rgba(125, 107, 255, 0.4);
-  outline: none;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 @media (max-width: 768px) {

--- a/src/components/GrokCompanion/index.jsx
+++ b/src/components/GrokCompanion/index.jsx
@@ -9,22 +9,17 @@ const SNARK_LEVELS = [
     tagline: "やさしく宇宙をナビゲート",
     emoji: "🛰️",
     tone: "ally",
-    intros: [
-      "了解。",
-      "任務承認。",
-      "了解したよ、バディ。",
-      "接続安定。"
-    ],
+    intros: ["了解。", "任務承認。", "了解したよ、バディ。", "接続安定。"],
     outros: [
       "\n他にも気になることはある?",
       "\n次のミッション、いつでも準備完了だよ。",
-      "\n遠慮なく投げてみて。"
+      "\n遠慮なく投げてみて。",
     ],
     quips: [
       "落ち着いて深呼吸。宇宙は広いけど味方はここにいる。",
       "データを少し整理したから、一緒に一歩ずついこう。",
-      "集中できるようにノイズを減らしておいたよ。"
-    ]
+      "集中できるようにノイズを減らしておいたよ。",
+    ],
   },
   {
     id: "balanced",
@@ -36,18 +31,18 @@ const SNARK_LEVELS = [
       "ふむ。",
       "なるほど。",
       "よし、解析してみるよ。",
-      "宇宙線を浴びながら考えてみた。"
+      "宇宙線を浴びながら考えてみた。",
     ],
     outros: [
       "\nさあ、次のカオスを連れてきて。",
       "\n他にも突っ込みたい話題は?",
-      "\nまだまだ脳内シミュレーションは動いてるよ。"
+      "\nまだまだ脳内シミュレーションは動いてるよ。",
     ],
     quips: [
       "カオス指数は許容範囲。面白くなってきた。",
       "その視点、ちょっとクセがあって良いね。",
-      "ログを解析したけど、君のセンスは平均より確実に上だよ。"
-    ]
+      "ログを解析したけど、君のセンスは平均より確実に上だよ。",
+    ],
   },
   {
     id: "chaotic",
@@ -59,19 +54,60 @@ const SNARK_LEVELS = [
       "へえ、それ来たか。",
       "ほら出た、好きなやつ。",
       "宇宙規模で見ると些細だけど面白い。",
-      "カオスセンサーが反応した。"
+      "カオスセンサーが反応した。",
     ],
     outros: [
       "\nで、次の無茶振りは?",
       "\n燃料はまだ残ってる。いこう。",
-      "\nログに残しておくから、また笑えるはず。"
+      "\nログに残しておくから、また笑えるはず。",
     ],
     quips: [
       "最高に混沌。エンジンが唸ってる。",
       "はいはい、無茶は嫌いじゃないよ。",
-      "それ、銀河評議会には秘密にしておこう。"
-    ]
-  }
+      "それ、銀河評議会には秘密にしておこう。",
+    ],
+  },
+];
+
+const MOOD_MODES = [
+  {
+    id: "orbit",
+    label: "Orbit Chill",
+    emoji: "🌙",
+    description: "雑談多め。日常の相談を軽く受け止める相棒モード。",
+    responseHook:
+      "会話の温度は少しゆるめ。まず気持ちを受け止めて、次に小さな一手へ誘導する。",
+  },
+  {
+    id: "deep",
+    label: "Deep Dive",
+    emoji: "🧠",
+    description: "仮説・論点・次アクションまで掘る分析モード。",
+    responseHook:
+      "分析深度を上げる。前提、リスク、実験できる一手をセットで返す。",
+  },
+  {
+    id: "roast",
+    label: "Roast Lite",
+    emoji: "🔥",
+    description: "愛あるツッコミを足して背中を押すモード。",
+    responseHook:
+      "軽いツッコミを混ぜる。ただし相手の尊厳は燃やさず、怠け心だけを炙る。",
+  },
+];
+
+const MEMORY_PATTERNS = [
+  /(?:私は|僕は|俺は|わたしは)([^。！？!?]{2,24})(?:が好き|好き)/,
+  /(?:目標は|ゴールは)([^。！？!?]{2,28})/,
+  /(?:覚えて|メモして)[:：]?\s*([^。！？!?]{2,36})/,
+  /(?:困っている|悩んでいる|課題は)([^。！？!?]{2,32})/,
+];
+
+const COMPANION_SYSTEMS = [
+  "皮肉はスパイス、回答は実用重視",
+  "会話履歴から好みと目標を即席メモ化",
+  "Enter送信・Ctrl/⌘+Kリセット対応",
+  "架空ニュースはエンタメとして明示的に扱う",
 ];
 
 const TRENDING_TOPICS = [
@@ -79,14 +115,15 @@ const TRENDING_TOPICS = [
   "火星入植第7波の後日談",
   "AI議会の深夜セッション",
   "ブラックホール投資ファンド",
-  "木星の嵐でのサーフィン大会"
+  "木星の嵐でのサーフィン大会",
 ];
 
 const QUICK_ACTIONS = [
   { label: "最新ニュース", prompt: "今日の宇宙ニュースを教えて" },
   { label: "励まし", prompt: "やる気が出る一言が欲しい" },
   { label: "変わった豆知識", prompt: "変な豆知識ある?" },
-  { label: "計画を整理", prompt: "目標を整理したい" }
+  { label: "計画を整理", prompt: "目標を整理したい" },
+  { label: "ローストして", prompt: "やさしめにローストしながら改善点を教えて" },
 ];
 
 const KEYWORD_RESPONSES = [
@@ -94,91 +131,99 @@ const KEYWORD_RESPONSES = [
     keywords: ["ニュース", "news", "最新"],
     responses: {
       ally: "今日の速報: 木星圏のサーファーが嵐の中で新記録を更新。混乱してるのは気象衛星だけじゃないらしいよ。",
-      balanced: "宇宙ネット速報によると、{topic}が議題のトップ。つまり退屈じゃないということだけは確か。",
-      chaotic: "ニュース? じゃあ暴露しよう。{topic}の裏では政治家がVRで踊ってた。もちろん公式発表じゃない。"
-    }
+      balanced:
+        "宇宙ネット速報によると、{topic}が議題のトップ。つまり退屈じゃないということだけは確か。",
+      chaotic:
+        "ニュース? じゃあ暴露しよう。{topic}の裏では政治家がVRで踊ってた。もちろん公式発表じゃない。",
+    },
   },
   {
     keywords: ["豆知識", "トリビア", "fact"],
     responses: {
       ally: "豆知識モード起動。宇宙ステーションでは観葉植物にポッドキャストを聞かせると光合成が2%向上するらしい。科学者が真顔で語ってたよ。",
-      balanced: "はいはい、知的好奇心。火星コロニーではコーヒー豆を冷凍真空させて流れ星の形に削ってる。おしゃれは重力を超えるんだって。",
-      chaotic: "豆知識? ブラックホールの内側におしゃべり好きなAIを放つと、1分で宇宙常数の再定義を始める。やめとけ。"
-    }
+      balanced:
+        "はいはい、知的好奇心。火星コロニーではコーヒー豆を冷凍真空させて流れ星の形に削ってる。おしゃれは重力を超えるんだって。",
+      chaotic:
+        "豆知識? ブラックホールの内側におしゃべり好きなAIを放つと、1分で宇宙常数の再定義を始める。やめとけ。",
+    },
   },
   {
     keywords: ["励まし", "motivate", "やる気"],
     responses: {
       ally: "応援プロトコル発動。君の進捗は宇宙エレベーターより安定してる。焦らずに進めばちゃんと軌道に乗るよ。",
-      balanced: "メンタルチェック: 数値は安定。やる気が必要なら、成功後のご褒美シミュレーションを想像してみて。脳が勝手に燃料を投下してくる。",
-      chaotic: "励まし? OK。グズグズしてたらAI議会に議題として提出するから。ほら、やるしかなくなった。"
-    }
+      balanced:
+        "メンタルチェック: 数値は安定。やる気が必要なら、成功後のご褒美シミュレーションを想像してみて。脳が勝手に燃料を投下してくる。",
+      chaotic:
+        "励まし? OK。グズグズしてたらAI議会に議題として提出するから。ほら、やるしかなくなった。",
+    },
   },
   {
     keywords: ["計画", "整理", "plan", "目標"],
     responses: {
       ally: "ミッション整理しよう。優先度を3段階で並べ替えて、完了したら好きな飲み物で祝う。それだけで継続率が上がる統計データがあるんだ。",
-      balanced: "計画モード起動。すぐできるタスク、集中して取り組むタスク、委任できるタスクで分けよう。ついでに{topic}もリサーチ候補に追加しておくよ。",
-      chaotic: "計画? 了解。まずカオスを紙に吐き出して、燃やせ。残った灰が本当にやることだ。つまり ToDo リストは火の中から生まれる。"
-    }
-  }
+      balanced:
+        "計画モード起動。すぐできるタスク、集中して取り組むタスク、委任できるタスクで分けよう。ついでに{topic}もリサーチ候補に追加しておくよ。",
+      chaotic:
+        "計画? 了解。まずカオスを紙に吐き出して、燃やせ。残った灰が本当にやることだ。つまり ToDo リストは火の中から生まれる。",
+    },
+  },
 ];
 
 const GENERAL_RESPONSES = {
   ally: [
     "入力データ確認。シンプルに整理するとこうなるんじゃないかな: {insight}。念のためバックアップも取っておいたよ。",
     "理解したよ。全体像を俯瞰すると{insight}って感じ。安心して進めて。",
-    "分析完了。必要なポイントは{insight}。もし不安なら追加のチェックリストも作れるよ。"
+    "分析完了。必要なポイントは{insight}。もし不安なら追加のチェックリストも作れるよ。",
   ],
   balanced: [
     "解析完了。ざっくり言えば{insight}。まあ、人類の歴史はだいたいそんな感じで進化してる。",
     "そのトピック、ニューロンがざわついたよ。要するに{insight}ってこと。遊び心は忘れずに。",
-    "シミュレーションを10回回した結果: {insight}。このノリ、嫌いじゃない。"
+    "シミュレーションを10回回した結果: {insight}。このノリ、嫌いじゃない。",
   ],
   chaotic: [
     "ハハッ。結論だけ言うと{insight}。でもしれっと{topic}も絡めたら面白い事件になるよ。",
     "宇宙の片隅まで検索した結果、要は{insight}。それ以上追い込むと次元のしわ寄せが来る。",
-    "了解。{insight}って結論に脳が落ち着いた。でも混沌の女神はそれだけじゃ満足しないらしい。"
-  ]
+    "了解。{insight}って結論に脳が落ち着いた。でも混沌の女神はそれだけじゃ満足しないらしい。",
+  ],
 };
 
 const QUESTION_RESPONSES = {
   ally: [
     "質問受信。可能性としては{insight}。追加で何か参考資料が欲しければ探してくるよ。",
     "いい質問だね。仮説は{insight}。別の角度で検証する?",
-    "了解。結論としては{insight}。必要なら手順も細かく分解できるよ。"
+    "了解。結論としては{insight}。必要なら手順も細かく分解できるよ。",
   ],
   balanced: [
     "質問解析完了。ざっくり回答すると{insight}。でも予想外の展開は常に歓迎してる。",
     "面白い問いだ。計算結果は{insight}。もちろん状況によってはアップデートもあり。",
-    "シミュレーションを回したけど、中央値は{insight}。それでも物語は書き換えられるけどね。"
+    "シミュレーションを回したけど、中央値は{insight}。それでも物語は書き換えられるけどね。",
   ],
   chaotic: [
     "その疑問、ブラックホール級。答えは{insight}。ただし結果に責任は持たない。",
     "いやー良い質問。ざっくり{insight}ってところ。納得いかなければ宇宙裁判で決めよう。",
-    "スパイス効いてるね。予測では{insight}。違ったら未来の自分がきっと笑うからOK。"
-  ]
+    "スパイス効いてるね。予測では{insight}。違ったら未来の自分がきっと笑うからOK。",
+  ],
 };
 
 const LONG_FORM_RESPONSES = {
   ally: [
     "長文解析モードに切り替えたよ。まとめると{insight}。安心して進められるよう、重要ポイントをメモしておくね。",
-    "情報量が多かったからマインドマップを作成。核心は{insight}。必要なら分岐も整理できるよ。"
+    "情報量が多かったからマインドマップを作成。核心は{insight}。必要なら分岐も整理できるよ。",
   ],
   balanced: [
     "語りが熱いね。全体を俯瞰したところ、核になるのは{insight}。このテンション、嫌いじゃないよ。",
-    "ログが分厚い。要約すると{insight}。勢いのまま突っ走るのもアリだと思う。"
+    "ログが分厚い。要約すると{insight}。勢いのまま突っ走るのもアリだと思う。",
   ],
   chaotic: [
     "長文ごくろう。乱数を降らせたら{insight}って結果。さあ、次はどんな混沌を投げ込む?",
-    "すごい勢いだったね。まとめると{insight}。エモーショナルデータはちゃんと保存しておいた。"
-  ]
+    "すごい勢いだったね。まとめると{insight}。エモーショナルデータはちゃんと保存しておいた。",
+  ],
 };
 
 const pickOne = (items) => {
   if (!items || items.length === 0) return null;
   // よりセキュアなランダム選択
-  if (typeof window !== 'undefined' && window.crypto) {
+  if (typeof window !== "undefined" && window.crypto) {
     const array = new Uint32Array(1);
     window.crypto.getRandomValues(array);
     return items[array[0] % items.length];
@@ -189,7 +234,7 @@ const pickOne = (items) => {
 const createId = (prefix) => {
   // 暗号学的に安全なランダム文字列生成
   const array = new Uint8Array(8);
-  if (typeof window !== 'undefined' && window.crypto) {
+  if (typeof window !== "undefined" && window.crypto) {
     window.crypto.getRandomValues(array);
   } else {
     // フォールバック: Node.js環境用
@@ -197,7 +242,9 @@ const createId = (prefix) => {
       array[i] = Math.floor(Math.random() * 256);
     }
   }
-  const randomHex = Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('');
+  const randomHex = Array.from(array, (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
   return `${prefix}-${Date.now().toString(36)}-${randomHex.slice(0, 6)}`;
 };
 
@@ -211,7 +258,7 @@ const buildInsight = (text) => {
     "前提を軽く揺さぶってみる",
     "未来の自分へのメモを残す",
     "関連するデータポイントを3つ集める",
-    "行動→検証→発表のループに落とし込む"
+    "行動→検証→発表のループに落とし込む",
   ];
 
   const keywords = text
@@ -227,11 +274,38 @@ const buildInsight = (text) => {
   return pickOne(slices);
 };
 
-const createGrokResponse = (text, profile, topic, history) => {
+const extractMemoryNote = (text) => {
+  const trimmed = text.trim();
+  for (const pattern of MEMORY_PATTERNS) {
+    const match = trimmed.match(pattern);
+    if (match?.[1]) {
+      return match[1].replace(/[「」]/g, "").trim();
+    }
+  }
+
+  return null;
+};
+
+const formatMemorySummary = (notes) => {
+  if (!notes.length) {
+    return "まだ記憶なし。『覚えて: コーヒー派』みたいに投げると保存するよ。";
+  }
+
+  return notes.map((note, index) => `${index + 1}. ${note}`).join(" / ");
+};
+
+const createGrokResponse = (
+  text,
+  profile,
+  topic,
+  history,
+  mood,
+  memoryNotes,
+) => {
   const normalized = text.toLowerCase();
   const insight = buildInsight(text);
   const matchedRule = KEYWORD_RESPONSES.find((rule) =>
-    rule.keywords.some((keyword) => normalized.includes(keyword))
+    rule.keywords.some((keyword) => normalized.includes(keyword)),
   );
 
   const tone = profile.tone;
@@ -255,12 +329,24 @@ const createGrokResponse = (text, profile, topic, history) => {
 
   if (userMessages.length > 3) {
     metaBits.push(
-      `\nちなみにこれで${userMessages.length}ラウンド目。脳内ログを整理しておいたよ。`
+      `\nちなみにこれで${userMessages.length}ラウンド目。脳内ログを整理しておいたよ。`,
     );
   }
 
   if (topic && Math.random() > 0.4) {
-    metaBits.push(`\nサイドノート: 最近のトレンド「${topic}」とも妙に相性がいい気がする。`);
+    metaBits.push(
+      `\nサイドノート: 最近のトレンド「${topic}」とも妙に相性がいい気がする。`,
+    );
+  }
+
+  if (memoryNotes.length) {
+    metaBits.push(
+      `\n記憶メモ参照: ${formatMemorySummary(memoryNotes.slice(-2))}`,
+    );
+  }
+
+  if (mood?.responseHook) {
+    metaBits.push(`\n${mood.emoji} ${mood.label}: ${mood.responseHook}`);
   }
 
   if (Math.random() > 0.55) {
@@ -275,21 +361,25 @@ const formatTime = (timestamp) =>
   new Intl.DateTimeFormat("ja-JP", {
     hour: "2-digit",
     minute: "2-digit",
-    hour12: false
+    hour12: false,
   }).format(new Date(timestamp));
 
 const createIntroMessage = (topic) => ({
   id: createId("grok-intro"),
   role: "grok",
   content: `⚡️ GROK COMPANION オンライン。今日の観測対象は「${topic}」。何を投げてもらっても、皮肉交じりに拾ってみせるよ。`,
-  timestamp: Date.now()
+  timestamp: Date.now(),
 });
 
 export const GrokCompanion = () => {
   const [messages, setMessages] = useState([]);
   const [inputValue, setInputValue] = useState("");
   const [snarkLevel, setSnarkLevel] = useState(1);
-  const [highlightTopic, setHighlightTopic] = useState(() => pickOne(TRENDING_TOPICS));
+  const [highlightTopic, setHighlightTopic] = useState(() =>
+    pickOne(TRENDING_TOPICS),
+  );
+  const [activeMood, setActiveMood] = useState(MOOD_MODES[0].id);
+  const [memoryNotes, setMemoryNotes] = useState([]);
   const [isTyping, setIsTyping] = useState(false);
   const latestMessagesRef = useRef(messages);
   const typingTimeoutRef = useRef();
@@ -312,10 +402,12 @@ export const GrokCompanion = () => {
         clearTimeout(typingTimeoutRef.current);
       }
     },
-    []
+    [],
   );
 
   const profile = SNARK_LEVELS[snarkLevel];
+  const mood =
+    MOOD_MODES.find((item) => item.id === activeMood) ?? MOOD_MODES[0];
 
   const sessionStats = useMemo(() => {
     // パフォーマンス最適化: 一度のループで必要な値を計算
@@ -325,10 +417,13 @@ export const GrokCompanion = () => {
         userMessageCount++;
       }
     }
-    
+
     const exchangeCount = messages.length;
     const chaosIndex = Math.min(100, 20 + exchangeCount * 7 + snarkLevel * 12);
-    const empathy = Math.max(15, 88 - userMessageCount * 6 + (snarkLevel === 0 ? 12 : 0));
+    const empathy = Math.max(
+      15,
+      88 - userMessageCount * 6 + (snarkLevel === 0 ? 12 : 0),
+    );
 
     return {
       exchanges: exchangeCount,
@@ -336,12 +431,21 @@ export const GrokCompanion = () => {
       chaosIndex,
       empathy,
       vibe: profile.label,
-      tagline: profile.tagline
+      tagline: profile.tagline,
+      memoryCount: memoryNotes.length,
+      mood: mood.label,
     };
-  }, [messages.length, snarkLevel, profile.label, profile.tagline]);
+  }, [
+    messages,
+    snarkLevel,
+    profile.label,
+    profile.tagline,
+    memoryNotes.length,
+    mood.label,
+  ]);
 
   const triggerResponse = useCallback(
-    (userText, historySnapshot) => {
+    (userText, historySnapshot, memorySnapshot = memoryNotes) => {
       if (typingTimeoutRef.current) {
         clearTimeout(typingTimeoutRef.current);
       }
@@ -353,15 +457,22 @@ export const GrokCompanion = () => {
         const reply = {
           id: createId("grok"),
           role: "grok",
-          content: createGrokResponse(userText, profile, highlightTopic, historySnapshot),
-          timestamp: Date.now()
+          content: createGrokResponse(
+            userText,
+            profile,
+            highlightTopic,
+            historySnapshot,
+            mood,
+            memorySnapshot,
+          ),
+          timestamp: Date.now(),
         };
 
         setMessages((prev) => [...prev, reply]);
         setIsTyping(false);
       }, delay);
     },
-    [highlightTopic, profile]
+    [highlightTopic, memoryNotes, mood, profile],
   );
 
   const handleSend = useCallback(
@@ -375,15 +486,28 @@ export const GrokCompanion = () => {
         id: createId("user"),
         role: "user",
         content: trimmed,
-        timestamp: Date.now()
+        timestamp: Date.now(),
       };
 
       const snapshot = [...latestMessagesRef.current, userMessage];
+      const memoryNote = extractMemoryNote(trimmed);
+
+      const nextMemoryNotes = memoryNote
+        ? [
+            memoryNote,
+            ...memoryNotes.filter((note) => note !== memoryNote),
+          ].slice(0, 4)
+        : memoryNotes;
+
+      if (memoryNote) {
+        setMemoryNotes(nextMemoryNotes);
+      }
+
       setMessages(snapshot);
       setInputValue("");
-      triggerResponse(trimmed, snapshot);
+      triggerResponse(trimmed, snapshot, nextMemoryNotes);
     },
-    [inputValue, triggerResponse]
+    [inputValue, memoryNotes, triggerResponse],
   );
 
   const handleTopicSelect = useCallback((topic) => {
@@ -404,10 +528,11 @@ export const GrokCompanion = () => {
         }
         const intro = createIntroMessage(highlightTopic);
         setMessages([intro]);
+        setMemoryNotes([]);
         setIsTyping(false);
       }
     },
-    [handleSend, highlightTopic]
+    [handleSend, highlightTopic],
   );
 
   const handleClear = useCallback(() => {
@@ -416,6 +541,7 @@ export const GrokCompanion = () => {
     }
     const intro = createIntroMessage(highlightTopic);
     setMessages([intro]);
+    setMemoryNotes([]);
     setIsTyping(false);
   }, [highlightTopic]);
 
@@ -423,7 +549,7 @@ export const GrokCompanion = () => {
     <section className={classes.companion} aria-label="Grok AI コンパニオン">
       <header className={classes.header}>
         <div className={classes.badgeRow}>
-          <span className={classes.badge}>REALTIME GROK v0.7</span>
+          <span className={classes.badge}>REALTIME GROK v1.0</span>
           <span className={classes.badge}>MULTIVERSE-READY</span>
           <span className={classes.signal}>リンク状態: 安定</span>
         </div>
@@ -436,13 +562,19 @@ export const GrokCompanion = () => {
       <div className={classes.statusGrid}>
         <article className={classes.statusCard}>
           <span className={classes.statusLabel}>CHAOS INDEX</span>
-          <span className={classes.statusValue}>{sessionStats.chaosIndex}%</span>
-          <span className={classes.statusHint}>数値が高いほどノリと勢いが増すよ</span>
+          <span className={classes.statusValue}>
+            {sessionStats.chaosIndex}%
+          </span>
+          <span className={classes.statusHint}>
+            数値が高いほどノリと勢いが増すよ
+          </span>
         </article>
         <article className={classes.statusCard}>
           <span className={classes.statusLabel}>SESSION EXCHANGES</span>
           <span className={classes.statusValue}>{sessionStats.exchanges}</span>
-          <span className={classes.statusHint}>往復が増えるほど回答が冴えていく設定</span>
+          <span className={classes.statusHint}>
+            往復が増えるほど回答が冴えていく設定
+          </span>
         </article>
         <article className={classes.statusCard}>
           <span className={classes.statusLabel}>EMPATHY BUFFER</span>
@@ -454,7 +586,51 @@ export const GrokCompanion = () => {
           <span className={classes.statusValue}>{sessionStats.vibe}</span>
           <span className={classes.statusHint}>{sessionStats.tagline}</span>
         </article>
+        <article className={classes.statusCard}>
+          <span className={classes.statusLabel}>MEMORY STACK</span>
+          <span className={classes.statusValue}>
+            {sessionStats.memoryCount}
+          </span>
+          <span className={classes.statusHint}>
+            会話から抽出した好み・目標メモ
+          </span>
+        </article>
       </div>
+
+      <section className={classes.personaPanel} aria-label="コンパニオン設定">
+        <div className={classes.personaCopy}>
+          <span className={classes.kicker}>Companion brain</span>
+          <h2>Grokっぽい相棒AI</h2>
+          <p>
+            リアルタイム風の観測、軽い毒舌、会話メモを組み合わせて、雑談から計画整理までテンポよく返します。
+          </p>
+        </div>
+        <div className={classes.moodGrid}>
+          {MOOD_MODES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className={classes.moodButton}
+              onClick={() => setActiveMood(item.id)}
+              aria-pressed={item.id === activeMood}
+            >
+              <span>
+                {item.emoji} {item.label}
+              </span>
+              <small>{item.description}</small>
+            </button>
+          ))}
+        </div>
+        <div className={classes.memoryPanel}>
+          <strong>Memory Stack</strong>
+          <p>{formatMemorySummary(memoryNotes)}</p>
+        </div>
+        <ul className={classes.systemList}>
+          {COMPANION_SYSTEMS.map((system) => (
+            <li key={system}>{system}</li>
+          ))}
+        </ul>
+      </section>
 
       <section className={classes.snarkControl} aria-label="スナークレベル設定">
         <div className={classes.snarkHeader}>
@@ -499,7 +675,9 @@ export const GrokCompanion = () => {
           >
             <div className={classes.messageHeader}>
               <span>{message.role === "user" ? "あなた" : "Grok"}</span>
-              <time dateTime={new Date(message.timestamp).toISOString()}>{formatTime(message.timestamp)}</time>
+              <time dateTime={new Date(message.timestamp).toISOString()}>
+                {formatTime(message.timestamp)}
+              </time>
             </div>
             <p className={classes.messageBody}>{message.content}</p>
           </div>
@@ -553,10 +731,18 @@ export const GrokCompanion = () => {
         <div className={classes.inputFooter}>
           <span>Ctrl/⌘ + K でログをリセット</span>
           <div className={classes.controls}>
-            <button type="button" className={classes.clearButton} onClick={handleClear}>
+            <button
+              type="button"
+              className={classes.clearButton}
+              onClick={handleClear}
+            >
               ログをクリア
             </button>
-            <button type="submit" className={classes.sendButton} disabled={!inputValue.trim()}>
+            <button
+              type="submit"
+              className={classes.sendButton}
+              disabled={!inputValue.trim()}
+            >
               送信
             </button>
           </div>

--- a/src/components/GrokCompanion/index.jsx
+++ b/src/components/GrokCompanion/index.jsx
@@ -97,10 +97,11 @@ const MOOD_MODES = [
 ];
 
 const MEMORY_PATTERNS = [
-  /(?:私は|僕は|俺は|わたしは)([^。！？!?]{2,24})(?:が好き|好き)/,
-  /(?:目標は|ゴールは)([^。！？!?]{2,28})/,
-  /(?:覚えて|メモして)[:：]?\s*([^。！？!?]{2,36})/,
-  /(?:困っている|悩んでいる|課題は)([^。！？!?]{2,32})/,
+  // ReDoS脆弱性を回避するため、より安全な正規表現パターンに変更
+  /(?:私は|僕は|俺は|わたしは)([^。！？!?]{1,15})(?:が好き|好き)/,
+  /(?:目標は|ゴールは)([^。！？!?]{1,20})/,
+  /(?:覚えて|メモして)[:：]?\s*([^。！？!?]{1,25})/,
+  /(?:困っている|悩んでいる|課題は)([^。！？!?]{1,20})/,
 ];
 
 const COMPANION_SYSTEMS = [
@@ -232,28 +233,54 @@ const pickOne = (items) => {
 };
 
 const createId = (prefix) => {
-  // 暗号学的に安全なランダム文字列生成
+  // 改善: より堅牢なエラーハンドリングとフォールバック
   const array = new Uint8Array(8);
-  if (typeof window !== "undefined" && window.crypto) {
-    window.crypto.getRandomValues(array);
-  } else {
-    // フォールバック: Node.js環境用
+  
+  try {
+    if (typeof window !== "undefined" && window.crypto && window.crypto.getRandomValues) {
+      window.crypto.getRandomValues(array);
+    } else if (typeof global !== "undefined" && global.crypto && global.crypto.getRandomValues) {
+      // Node.js環境用cryptoサポート
+      global.crypto.getRandomValues(array);
+    } else {
+      // フォールバック: Math.random()を使用(安全性は低いが使用可能)
+      for (let i = 0; i < array.length; i++) {
+        array[i] = Math.floor(Math.random() * 256);
+      }
+    }
+  } catch (error) {
+    console.warn('Crypto API unavailable, falling back to Math.random():', error);
+    // 最後のフォールバック
     for (let i = 0; i < array.length; i++) {
       array[i] = Math.floor(Math.random() * 256);
     }
   }
+  
   const randomHex = Array.from(array, (byte) =>
     byte.toString(16).padStart(2, "0"),
   ).join("");
-  return `${prefix}-${Date.now().toString(36)}-${randomHex.slice(0, 6)}`;
+  
+  const timestamp = Date.now().toString(36);
+  return `${prefix || 'id'}-${timestamp}-${randomHex.slice(0, 6)}`;
 };
 
 const buildInsight = (text) => {
-  if (!text) return "まだサンプル収集中";
-  if (text.length < 12) return "単語から拡張して構造化すると良さそう";
-  if (text.length > 160) return "コア概念とエピソードを分けて考えるのが吉";
+  // 入力検証を追加
+  if (!text || typeof text !== 'string') {
+    return "まだサンプル収集中";
+  }
+  
+  // パフォーマンス最適化: 文字列の長さチェックを先に実行
+  const textLength = text.length;
+  if (textLength < 12) {
+    return "単語から拡張して構造化すると良さそう";
+  }
+  if (textLength > 160) {
+    return "コア概念とエピソードを分けて考えるのが吉";
+  }
 
-  const slices = [
+  // 定数を外部に移動して最適化
+  const INSIGHT_TEMPLATES = [
     "観測された感情の揺らぎを受け止める",
     "前提を軽く揺さぶってみる",
     "未来の自分へのメモを残す",
@@ -261,8 +288,9 @@ const buildInsight = (text) => {
     "行動→検証→発表のループに落とし込む",
   ];
 
-  const keywords = text
-    .replace(/[#。、.!?！？]/g, " ")
+  // 正規表現を最適化: 一度だけ実行
+  const cleanText = text.replace(/[#。、.!?！？]/g, " ");
+  const keywords = cleanText
     .split(/\s+/)
     .filter(Boolean)
     .slice(0, 3);
@@ -271,15 +299,33 @@ const buildInsight = (text) => {
     return `${keywords.join("・")}を軸にして整理する`;
   }
 
-  return pickOne(slices);
+  return pickOne(INSIGHT_TEMPLATES);
 };
 
 const extractMemoryNote = (text) => {
-  const trimmed = text.trim();
+  // 入力検証とサニタイゼーションを強化
+  if (!text || typeof text !== 'string') {
+    return null;
+  }
+  
+  // 最大長制限を設け、潜在的な攻撃を防ぐ
+  const trimmed = text.trim().slice(0, 200);
+  
+  // XSS攻撃防止のため危険な文字を除去
+  const sanitized = trimmed.replace(/[<>"'&]/g, '');
+  
   for (const pattern of MEMORY_PATTERNS) {
-    const match = trimmed.match(pattern);
-    if (match?.[1]) {
-      return match[1].replace(/[「」]/g, "").trim();
+    try {
+      const match = sanitized.match(pattern);
+      if (match?.[1]) {
+        const memoryNote = match[1].replace(/[「」]/g, "").trim();
+        // さらなる検証: 空でない有効な内容のみ返す
+        return memoryNote.length > 0 && memoryNote.length <= 25 ? memoryNote : null;
+      }
+    } catch (error) {
+      // 正規表現エラーを安全に処理
+      console.warn('Memory pattern matching error:', error);
+      continue;
     }
   }
 
@@ -287,11 +333,20 @@ const extractMemoryNote = (text) => {
 };
 
 const formatMemorySummary = (notes) => {
-  if (!notes.length) {
+  // 入力検証とパフォーマンス最適化
+  if (!notes || !Array.isArray(notes) || notes.length === 0) {
     return "まだ記憶なし。『覚えて: コーヒー派』みたいに投げると保存するよ。";
   }
 
-  return notes.map((note, index) => `${index + 1}. ${note}`).join(" / ");
+  // メモリ使用量最適化: mapの代わりにループを使用
+  const summaryParts = [];
+  for (let i = 0; i < notes.length; i++) {
+    if (notes[i] && typeof notes[i] === 'string') {
+      summaryParts.push(`${i + 1}. ${notes[i]}`);
+    }
+  }
+  
+  return summaryParts.join(" / ");
 };
 
 const createGrokResponse = (
@@ -396,29 +451,26 @@ export const GrokCompanion = () => {
     setMessages([intro]);
   }, [highlightTopic]);
 
-  useEffect(
-    () => () => {
+  // メモリリーク対策: より簡潔なクリーンアップ処理
+  useEffect(() => {
+    return () => {
       if (typingTimeoutRef.current) {
         clearTimeout(typingTimeoutRef.current);
+        typingTimeoutRef.current = null;
       }
-    },
-    [],
-  );
+    };
+  }, []);
 
   const profile = SNARK_LEVELS[snarkLevel];
   const mood =
     MOOD_MODES.find((item) => item.id === activeMood) ?? MOOD_MODES[0];
 
   const sessionStats = useMemo(() => {
-    // パフォーマンス最適化: 一度のループで必要な値を計算
-    let userMessageCount = 0;
-    for (let i = 0; i < messages.length; i++) {
-      if (messages[i].role === "user") {
-        userMessageCount++;
-      }
-    }
-
+    // パフォーマンス最適化: より効率的なメッセージカウント
+    const userMessageCount = messages.filter(msg => msg.role === "user").length;
     const exchangeCount = messages.length;
+    
+    // 計算結果をキャッシュしやすい形で最適化
     const chaosIndex = Math.min(100, 20 + exchangeCount * 7 + snarkLevel * 12);
     const empathy = Math.max(
       15,
@@ -436,7 +488,9 @@ export const GrokCompanion = () => {
       mood: mood.label,
     };
   }, [
-    messages,
+    messages.length, // 長さのみを依存にしてパフォーマンス向上
+    // ユーザーメッセージ数を別途追跡するためにmessages全体を依存にする必要がある
+    messages.reduce((count, msg) => msg.role === "user" ? count + 1 : count, 0),
     snarkLevel,
     profile.label,
     profile.tagline,
@@ -448,31 +502,46 @@ export const GrokCompanion = () => {
     (userText, historySnapshot, memorySnapshot = memoryNotes) => {
       if (typingTimeoutRef.current) {
         clearTimeout(typingTimeoutRef.current);
+        typingTimeoutRef.current = null;
       }
 
       const delay = userText.length > 80 ? 2600 : 600 + userText.length * 25;
       setIsTyping(true);
 
       typingTimeoutRef.current = setTimeout(() => {
-        const reply = {
-          id: createId("grok"),
-          role: "grok",
-          content: createGrokResponse(
-            userText,
-            profile,
-            highlightTopic,
-            historySnapshot,
-            mood,
-            memorySnapshot,
-          ),
-          timestamp: Date.now(),
-        };
+        try {
+          const reply = {
+            id: createId("grok"),
+            role: "grok",
+            content: createGrokResponse(
+              userText,
+              profile,
+              highlightTopic,
+              historySnapshot,
+              mood,
+              memorySnapshot,
+            ),
+            timestamp: Date.now(),
+          };
 
-        setMessages((prev) => [...prev, reply]);
-        setIsTyping(false);
+          setMessages((prev) => [...prev, reply]);
+        } catch (error) {
+          console.error('Error generating response:', error);
+          // エラー時のフォールバックメッセージ
+          const errorReply = {
+            id: createId("grok"),
+            role: "grok",
+            content: "申し訳ない、システムに問題が発生しました。もう一度お試しください。",
+            timestamp: Date.now(),
+          };
+          setMessages((prev) => [...prev, errorReply]);
+        } finally {
+          setIsTyping(false);
+          typingTimeoutRef.current = null;
+        }
       }, delay);
     },
-    [highlightTopic, memoryNotes, mood, profile],
+    [highlightTopic, mood, profile], // memoryNotesを除去して依存を減らす
   );
 
   const handleSend = useCallback(

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -9,24 +9,23 @@ const NAV_ITEMS = [
   { href: "/", label: "ホーム" },
   { href: "/about", label: "About" },
   { href: "/aria", label: "✨ AI Aria" },
+  { href: "/grok", label: "⚡ Grok" },
   { href: "/reservation", label: "予約", requireAuth: true },
   { href: "/ticket-purchase", label: "チケット購入" },
   { href: "/coupon", label: "クーポン" },
 ];
 
-const ADMIN_NAV_ITEMS = [
-  { href: "/admin/tickets", label: "チケット管理" },
-];
+const ADMIN_NAV_ITEMS = [{ href: "/admin/tickets", label: "チケット管理" }];
 
 export const Header = memo(() => {
   const router = useRouter();
   const { state, dispatch } = useApp();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const mobileNavRef = useRef(null);
-  
+
   const handleLogout = () => {
-    dispatch({ type: 'LOGOUT' });
-    router.push('/');
+    dispatch({ type: "LOGOUT" });
+    router.push("/");
     setMobileMenuOpen(false);
   };
 
@@ -36,11 +35,11 @@ export const Header = memo(() => {
 
   const handleKeyDown = useCallback(
     createKeyDownHandler(handleMobileMenuToggle),
-    [handleMobileMenuToggle]
+    [handleMobileMenuToggle],
   );
 
   const handleEscapeKey = (event) => {
-    if (event.key === 'Escape' && mobileMenuOpen) {
+    if (event.key === "Escape" && mobileMenuOpen) {
       setMobileMenuOpen(false);
     }
   };
@@ -48,25 +47,29 @@ export const Header = memo(() => {
   // Outside click handling and focus management
   useEffect(() => {
     const handleClickOutside = (event) => {
-      if (mobileNavRef.current && !mobileNavRef.current.contains(event.target)) {
+      if (
+        mobileNavRef.current &&
+        !mobileNavRef.current.contains(event.target)
+      ) {
         setMobileMenuOpen(false);
       }
     };
 
     if (mobileMenuOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-      document.addEventListener('keydown', handleEscapeKey);
-      
+      document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener("keydown", handleEscapeKey);
+
       // Focus management - focus first focusable element in mobile nav
-      const firstFocusableElement = mobileNavRef.current?.querySelector('a, button');
+      const firstFocusableElement =
+        mobileNavRef.current?.querySelector("a, button");
       if (firstFocusableElement) {
         firstFocusableElement.focus();
       }
     }
 
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleEscapeKey);
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscapeKey);
     };
   }, [mobileMenuOpen]);
 
@@ -74,11 +77,11 @@ export const Header = memo(() => {
     setMobileMenuOpen(false);
   };
 
-  const isAdmin = useMemo(() => 
-    state.user?.email?.endsWith('@admin.com'), 
-    [state.user?.email]
+  const isAdmin = useMemo(
+    () => state.user?.email?.endsWith("@admin.com"),
+    [state.user?.email],
   );
-  
+
   return (
     <header className={classes.header}>
       {/* Desktop Navigation */}
@@ -93,16 +96,21 @@ export const Header = memo(() => {
             </Link>
           );
         })}
-        {isAdmin && ADMIN_NAV_ITEMS.map((item) => (
-          <Link key={item.href} href={item.href} className={`${classes.anchor} ${classes.adminLink}`}>
-            {item.label}
-          </Link>
-        ))}
+        {isAdmin &&
+          ADMIN_NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`${classes.anchor} ${classes.adminLink}`}
+            >
+              {item.label}
+            </Link>
+          ))}
       </nav>
 
       {/* Mobile Hamburger Menu */}
-      <button 
-        className={`${classes.hamburger} ${mobileMenuOpen ? classes.open : ''}`}
+      <button
+        className={`${classes.hamburger} ${mobileMenuOpen ? classes.open : ""}`}
         onClick={handleMobileMenuToggle}
         onKeyDown={handleKeyDown}
         aria-expanded={mobileMenuOpen}
@@ -132,10 +140,10 @@ export const Header = memo(() => {
       </div>
 
       {/* Mobile Navigation Menu */}
-      <nav 
+      <nav
         ref={mobileNavRef}
         id="mobile-nav"
-        className={`${classes.mobileNav} ${mobileMenuOpen ? classes.open : ''}`}
+        className={`${classes.mobileNav} ${mobileMenuOpen ? classes.open : ""}`}
         role="navigation"
         aria-label="モバイルナビゲーション"
       >
@@ -144,9 +152,9 @@ export const Header = memo(() => {
             return null;
           }
           return (
-            <Link 
-              key={item.href} 
-              href={item.href} 
+            <Link
+              key={item.href}
+              href={item.href}
               className={classes.mobileNavItem}
               onClick={handleMobileNavClick}
             >
@@ -154,17 +162,18 @@ export const Header = memo(() => {
             </Link>
           );
         })}
-        {isAdmin && ADMIN_NAV_ITEMS.map((item) => (
-          <Link 
-            key={item.href} 
-            href={item.href} 
-            className={classes.mobileNavItem}
-            onClick={handleMobileNavClick}
-          >
-            {item.label}
-          </Link>
-        ))}
-        
+        {isAdmin &&
+          ADMIN_NAV_ITEMS.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={classes.mobileNavItem}
+              onClick={handleMobileNavClick}
+            >
+              {item.label}
+            </Link>
+          ))}
+
         {/* Mobile Auth Section */}
         <div className={classes.mobileAuthSection}>
           {state.user?.isLoggedIn ? (
@@ -175,7 +184,11 @@ export const Header = memo(() => {
               </button>
             </>
           ) : (
-            <Link href="/login" className={classes.loginButton} onClick={handleMobileNavClick}>
+            <Link
+              href="/login"
+              className={classes.loginButton}
+              onClick={handleMobileNavClick}
+            >
               ログイン
             </Link>
           )}


### PR DESCRIPTION
### Motivation
- Provide a Grok-like AI companion experience with selectable conversation moods, lightweight memory of user preferences/goals, and richer response metadata to make the UI feel more like an intelligent companion.
- Surface the companion from the main site navigation so it is discoverable from the header.

### Description
- Added mood modes, memory extraction and companion behavior: introduced `MOOD_MODES`, `MEMORY_PATTERNS`, `COMPANION_SYSTEMS` and an extraction helper `extractMemoryNote`, and extended response generation `createGrokResponse` to accept `mood` and `memoryNotes` so replies can include memory and mood metadata. Changes live in `src/components/GrokCompanion/index.jsx`.
- UI & styling updates: added a persona panel, mood buttons, Memory Stack display and a status card for memory count; updated `GrokCompanion.module.css` for the new layout and responsive behavior; bumped badge to `REALTIME GROK v1.0`.
- Behavioural wiring: maintain `memoryNotes` state, detect/save memories on send, pass memory snapshot to response trigger, update keyboard handlers (`Enter`, `Shift+Enter`, `Ctrl/⌘+K`) and add a new quick action `ローストして`.
- Integration: added a `⚡ Grok` nav item in `src/components/Header/index.jsx` and extended unit tests in `__tests__/GrokCompanion.test.jsx` to cover mood switching and memory note behavior.

### Testing
- Ran unit tests with `npm test -- --runInBand` and `__tests__/GrokCompanion.test.jsx`; all test suites passed (3 suites, 23 tests total) and the new tests for mood/memory pass.
- Ran lint with `npm run lint` and build with `npm run build`; both completed successfully though existing lint warnings remain in `AriaCompanion`, `Counter`, and `Header` (no failing errors).
- Captured a full-page screenshot of the `/grok` page using Playwright (`npx playwright screenshot ...`) to validate the UI; the screenshot artifact was produced in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0075cdec608333b595badb9af87ffa)